### PR TITLE
Update defaults to public functions

### DIFF
--- a/src/python_x509_pkcs11/ca.py
+++ b/src/python_x509_pkcs11/ca.py
@@ -5,7 +5,7 @@ Exposes the functions:
 """
 
 import datetime
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, Union
 
 from asn1crypto import pem as asn1_pem
 from asn1crypto.csr import (
@@ -20,7 +20,7 @@ from asn1crypto.keys import PublicKeyInfo
 from asn1crypto.x509 import BasicConstraints, Extension, ExtensionId, Extensions, KeyUsage, Name
 
 from .csr import sign_csr
-from .lib import signed_digest_algo
+from .lib import DEFAULT_KEY_TYPE, KEYTYPES, get_keytypes_enum, signed_digest_algo
 from .pkcs11_handle import PKCS11Session
 
 
@@ -168,11 +168,9 @@ def _create_tbs(
 
 
 async def _set_csr_signature(
-    key_label: str, key_type: Optional[str], signed_csr: CertificationRequest
+    key_label: str, signed_csr: CertificationRequest, key_type: KEYTYPES = DEFAULT_KEY_TYPE
 ) -> CertificationRequest:
     """Signs the given CSR with the given key and returns the signed CSR."""
-    if key_type is None:
-        key_type = "ed25519"
 
     signed_csr["signature_algorithm"] = signed_digest_algo(key_type)
     signed_csr["signature"] = await PKCS11Session().sign(
@@ -186,11 +184,11 @@ async def create(  # pylint: disable-msg=too-many-arguments,too-many-locals
     subject_name: Dict[str, str],
     signer_subject_name: Optional[Dict[str, str]] = None,
     signer_key_label: Optional[str] = None,
-    signer_key_type: Optional[str] = None,
+    signer_key_type: Optional[Union[str, KEYTYPES]] = None,
     not_before: Optional[datetime.datetime] = None,
     not_after: Optional[datetime.datetime] = None,
     extra_extensions: Optional[Extensions] = None,
-    key_type: Optional[str] = None,
+    key_type: Union[str, KEYTYPES] = DEFAULT_KEY_TYPE,
 ) -> Tuple[str, str]:
     """Creates a new HSM signed CA certificate.
 
@@ -206,14 +204,29 @@ async def create(  # pylint: disable-msg=too-many-arguments,too-many-locals
     not_before (Optional[datetime.datetime] = None): The ca is not valid before this time.
     not_after (Optional[datetime.datetime] = None): The ca is not valid after this time.
     extra_extensions (Optional[asn1crypto.x509.Extensions] = None]): x509 extensions to write into the ca.
-    key_type (Optional[str] = None): Key type to use, ed25519 is default.
+    key_type Union[str, KEYTYPES]: Key type to use, KEYTPES.ED25519 is default.
 
     Returns:
     Tuple[str, str]
     """
 
+    if isinstance(key_type, str):
+        internal_key_type = get_keytypes_enum(key_type)
+    else:
+        internal_key_type = key_type
+
+    # For the sign_csr
+    for_sign_csr = internal_key_type
+
+    # When we have the signer_key_type as a string
+    if signer_key_type and isinstance(signer_key_type, str):
+        internal_signer_key_type: KEYTYPES = get_keytypes_enum(signer_key_type)
+    elif signer_key_type and isinstance(signer_key_type, KEYTYPES):
+        # When we have the right KEYTYPES
+        internal_signer_key_type = signer_key_type
+
     # First create a new keypair in the HSM
-    pk_info, _ = await PKCS11Session().create_keypair(key_label, key_type=key_type)
+    pk_info, _ = await PKCS11Session().create_keypair(key_label, key_type=internal_key_type.value)
     data = pk_info.encode("utf-8")
     if asn1_pem.detect(data):
         _, _, data = asn1_pem.unarmor(data)
@@ -233,14 +246,14 @@ async def create(  # pylint: disable-msg=too-many-arguments,too-many-locals
     # https://github.com/wbond/asn1crypto/blob/b763a757bb2bef2ab63620611ddd8006d5e9e4a2/asn1crypto/csr.py#L128
     signed_csr = CertificationRequest()
     signed_csr["certification_request_info"] = tbs
-    signed_csr = await _set_csr_signature(key_label, key_type, signed_csr)
+    signed_csr = await _set_csr_signature(key_label, signed_csr, internal_key_type)
     pem_enc: bytes = asn1_pem.armor("CERTIFICATE REQUEST", signed_csr.dump())
 
     # It will be a self signed certificate unless we have proper signer_key_label and signer_subject_name and signer_key_type.
     if signer_key_label is not None and signer_subject_name is not None and signer_key_type:
         key_label = signer_key_label
         subject_name = signer_subject_name
-        key_type = signer_key_type
+        for_sign_csr = internal_signer_key_type
 
     return pem_enc.decode("utf-8"), await sign_csr(
         key_label,
@@ -249,5 +262,5 @@ async def create(  # pylint: disable-msg=too-many-arguments,too-many-locals
         not_before=not_before,
         not_after=not_after,
         keep_csr_extensions=True,
-        key_type=key_type,
+        key_type=for_sign_csr,
     )

--- a/src/python_x509_pkcs11/lib.py
+++ b/src/python_x509_pkcs11/lib.py
@@ -1,66 +1,88 @@
 """Module which have common functions and constants"""
 
-from typing import Dict, List
+from enum import Enum
+from typing import Dict, Set
 
 from asn1crypto.algos import SignedDigestAlgorithm, SignedDigestAlgorithmId
 from pkcs11 import KeyType
 
 DEBUG = False
 
-# Key types and sizes we support
-KEY_TYPES: List[str] = [
-    "ed25519",
-    "ed448",
-    "secp256r1",
-    "secp384r1",
-    "secp521r1",
-    "rsa_2048",
-    "rsa_4096",
-]
 
-KEY_TYPE_VALUES: Dict[str, KeyType] = {
-    "ed25519": KeyType.EC_EDWARDS,
-    "ed448": KeyType.EC_EDWARDS,
-    "secp256r1": KeyType.EC,
-    "secp384r1": KeyType.EC,
-    "secp521r1": KeyType.EC,
-    "rsa_2048": KeyType.RSA,
-    "rsa_4096": KeyType.RSA,
+# Enum for Key types and sizes we support
+class KEYTYPES(Enum):
+    ED25519 = "ed25519"
+    ED448 = "ed448"
+    SECP256r1 = "secp256r1"
+    SECP384r1 = "secp384r1"
+    SECP521r1 = "secp521r1"
+    RSA2048 = "rsa_2048"
+    RSA4096 = "rsa_4096"
+
+
+# This is the default key type
+DEFAULT_KEY_TYPE = KEYTYPES.ED25519
+
+KEY_TYPE_VALUES: Dict[KEYTYPES, KeyType] = {
+    KEYTYPES.ED25519: KeyType.EC_EDWARDS,
+    KEYTYPES.ED448: KeyType.EC_EDWARDS,
+    KEYTYPES.SECP256r1: KeyType.EC,
+    KEYTYPES.SECP384r1: KeyType.EC,
+    KEYTYPES.SECP521r1: KeyType.EC,
+    KEYTYPES.RSA2048: KeyType.RSA,
+    KEYTYPES.RSA4096: KeyType.RSA,
 }
 
 
-def signed_digest_algo(key_type: str) -> SignedDigestAlgorithm:
+def get_keytypes_enum(value: str) -> KEYTYPES:
+    """Returns the correct enum for the given key type.
+
+    :param value: key type as string.
+
+    :returns: KEYTYPES
+    :raises: ValueError if unknown key type.
+    """
+    if value == "ed25519":
+        return KEYTYPES.ED25519
+    elif value == "ed448":
+        return KEYTYPES.ED448
+    elif value == "secp256r1":
+        return KEYTYPES.SECP256r1
+    elif value == "secp384r1":
+        return KEYTYPES.SECP384r1
+    elif value == "secp521r1":
+        return KEYTYPES.SECP521r1
+    elif value == "rsa_2048":
+        return KEYTYPES.RSA2048
+    elif value == "rsa_4096":
+        return KEYTYPES.RSA4096
+    raise ValueError(f"{value} key type is not supported.")
+
+
+def signed_digest_algo(key_type: KEYTYPES) -> SignedDigestAlgorithm:
     """Return a SignedDigestAlgorithm valid for the key type
 
     Parameters:
-    key_type (str): Key type.
+    key_type (KEYTYPES): Key type.
 
     Returns:
     bytes
     """
 
-    if key_type == "ed25519":
-        algo = SignedDigestAlgorithm()
+    algo = SignedDigestAlgorithm()
+    if key_type == KEYTYPES.ED25519:
         algo["algorithm"] = SignedDigestAlgorithmId("ed25519")
-    elif key_type == "ed448":
-        algo = SignedDigestAlgorithm()
+    elif key_type == KEYTYPES.ED448:
         algo["algorithm"] = SignedDigestAlgorithmId("ed448")
-    elif key_type == "secp256r1":
-        algo = SignedDigestAlgorithm()
+    elif key_type == KEYTYPES.SECP256r1:
         algo["algorithm"] = SignedDigestAlgorithmId("sha256_ecdsa")
-    elif key_type == "secp384r1":
-        algo = SignedDigestAlgorithm()
+    elif key_type == KEYTYPES.SECP384r1:
         algo["algorithm"] = SignedDigestAlgorithmId("sha384_ecdsa")
-    elif key_type == "secp521r1":
-        algo = SignedDigestAlgorithm()
+    elif key_type == KEYTYPES.SECP521r1:
         algo["algorithm"] = SignedDigestAlgorithmId("sha512_ecdsa")
-    elif key_type == "rsa_2048":
-        algo = SignedDigestAlgorithm()
+    elif key_type == KEYTYPES.RSA2048:
         algo["algorithm"] = SignedDigestAlgorithmId("sha256_rsa")
-    elif key_type == "rsa_4096":
-        algo = SignedDigestAlgorithm()
+    elif key_type == KEYTYPES.RSA4096:
         algo["algorithm"] = SignedDigestAlgorithmId("sha512_rsa")
-    else:
-        raise ValueError(f"key_type must be in {KEY_TYPES}")
 
     return algo

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+import asyncio
+import os
+
+import pytest
+
+from src.python_x509_pkcs11.pkcs11_handle import PKCS11Session
+
+ON_GITHUB = bool(os.getenv("GITHUB_ACTIONS", False))
+
+
+async def delete_keys():
+    "We delete keys in a loop"
+    session = PKCS11Session()
+    keys = await session.key_labels()
+    for key_label, key_type in keys.items():
+        if key_label == "test_pkcs11_device_do_not_use":
+            continue
+        if key_label.startswith("testpkcs"):
+            await session.delete_keypair(key_label, key_type)
+            print(f"Deleted key {key_label=}")
+
+
+def pytest_sessionfinish(session: pytest.Session) -> None:
+    # Delete all test keys
+    asyncio.run(delete_keys())
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    # Delete all test keys
+    asyncio.run(delete_keys())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,10 @@ ON_GITHUB = bool(os.getenv("GITHUB_ACTIONS", False))
 
 async def delete_keys():
     "We delete keys in a loop"
+
+    # No need to delete keys in github actions.
+    if ON_GITHUB:
+        return
     session = PKCS11Session()
     keys = await session.key_labels()
     for key_label, key_type in keys.items():
@@ -17,7 +21,6 @@ async def delete_keys():
             continue
         if key_label.startswith("testpkcs"):
             await session.delete_keypair(key_label, key_type)
-            print(f"Deleted key {key_label=}")
 
 
 def pytest_sessionfinish(session: pytest.Session) -> None:

--- a/tests/test_ca.py
+++ b/tests/test_ca.py
@@ -15,7 +15,7 @@ from asn1crypto import x509 as asn1_x509
 from asn1crypto.core import GeneralizedTime
 
 from src.python_x509_pkcs11.ca import create
-from src.python_x509_pkcs11.lib import KEY_TYPES
+from src.python_x509_pkcs11.lib import KEYTYPES
 from src.python_x509_pkcs11.pkcs11_handle import PKCS11Session
 
 # Replace the above with this should you use this code
@@ -79,8 +79,8 @@ class TestCa(unittest.TestCase):
         Create and self sign a CSR with the key_label in the pkcs11 device.
         """
 
-        for key_type in KEY_TYPES:
-            new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        for key_type in KEYTYPES:
+            new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
             # Test non default key size
             _, root_cert_pem = asyncio.run(create(new_key_label[:-1], name_dict, key_type=key_type))
             data = root_cert_pem.encode("utf-8")
@@ -133,7 +133,7 @@ class TestCa(unittest.TestCase):
         with non default not_before and not_after.
         """
 
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
 
         # Test not_before parameter
         not_before = datetime.datetime(2022, 1, 1, tzinfo=datetime.timezone.utc)
@@ -176,7 +176,7 @@ class TestCa(unittest.TestCase):
         Create and selfsign a CSR with the key_label in the pkcs11 device.
         """
 
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         exts = asn1_csr.Extensions()
 
         pkup = asn1_x509.PrivateKeyUsagePeriod()
@@ -229,11 +229,11 @@ class TestCa(unittest.TestCase):
         Create an intermediate CA in the pkcs11 device.
         """
 
-        for key_type in KEY_TYPES:
-            new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        for key_type in KEYTYPES:
+            new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
             _, root_ca_pem = asyncio.run(create(new_key_label, signer_name_dict, key_type=key_type))
 
-            new_key_label2 = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+            new_key_label2 = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
             _, im_cert_pem = asyncio.run(
                 create(
                     new_key_label2,
@@ -304,10 +304,10 @@ class TestCa(unittest.TestCase):
         """
         Create an intermediate CA with different key label in the pkcs11 device.
         """
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         _, root_ca_pem = asyncio.run(create(new_key_label, signer_name_dict, key_type="ed25519"))
 
-        new_key_label2 = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label2 = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         _, im_cert_pem = asyncio.run(
             create(
                 new_key_label2,

--- a/tests/test_crl.py
+++ b/tests/test_crl.py
@@ -59,7 +59,7 @@ class TestCrl(unittest.TestCase):
         Create and sign a CRL with the key_label in the pkcs11 device.
         """
 
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         asyncio.run(PKCS11Session().create_keypair(new_key_label))
 
         crl_pem = asyncio.run(crl.create(new_key_label, subject_name))
@@ -98,7 +98,7 @@ class TestCrl(unittest.TestCase):
         """
 
         # Revoke first
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         asyncio.run(PKCS11Session().create_keypair(new_key_label))
         crl_pem1 = asyncio.run(crl.create(new_key_label, subject_name, serial_number=2342342342343456, reason=3))
         data = crl_pem1.encode("utf-8")
@@ -151,7 +151,7 @@ class TestCrl(unittest.TestCase):
         """
 
         # Revoke first
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         asyncio.run(PKCS11Session().create_keypair(new_key_label))
         with self.assertRaises(ValueError):
             asyncio.run(crl.create(new_key_label, subject_name, serial_number=2342342342343456, reason=33))
@@ -164,7 +164,7 @@ class TestCrl(unittest.TestCase):
         Create and sign a CRL with AKI.
         """
 
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         asyncio.run(PKCS11Session().create_keypair(new_key_label))
         _, identifier = asyncio.run(PKCS11Session().public_key_data(new_key_label))
         crl_pem1 = asyncio.run(crl.create(new_key_label, subject_name))
@@ -193,7 +193,7 @@ class TestCrl(unittest.TestCase):
         """
 
         # Both
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         next_update = datetime.datetime(2022, 1, 1, tzinfo=datetime.timezone.utc)
         this_update = datetime.datetime(2022, 1, 3, tzinfo=datetime.timezone.utc)
         asyncio.run(PKCS11Session().create_keypair(new_key_label))

--- a/tests/test_csr.py
+++ b/tests/test_csr.py
@@ -81,7 +81,7 @@ eHqaFEFZApnEybHb7JgdpW5TsnvPN1O5YC6bgbRTgLmwGe+pJ5cEtTwrSvWJra8G
 grASjklC2MWbAnXculQuvhPg5F54CK9WldMvd7oYAmbdGIWiffiL
 -----END CERTIFICATE REQUEST-----"""
 
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
 
         asyncio.run(PKCS11Session().create_keypair(new_key_label))
         cert_pem = asyncio.run(csr.sign_csr(new_key_label, issuer_name, csr_no_exts))
@@ -125,7 +125,7 @@ grASjklC2MWbAnXculQuvhPg5F54CK9WldMvd7oYAmbdGIWiffiL
         Sign a CSR with the key with the key_label in the pkcs11 device.
         """
 
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         asyncio.run(PKCS11Session().create_keypair(new_key_label))
         cert_pem = asyncio.run(csr.sign_csr(new_key_label, issuer_name, CSR_PEM))
 
@@ -154,7 +154,7 @@ grASjklC2MWbAnXculQuvhPg5F54CK9WldMvd7oYAmbdGIWiffiL
         Sign a CSR with the key with the key_label in the pkcs11 device.
         """
 
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         asyncio.run(PKCS11Session().create_keypair(new_key_label))
         cert_pem = asyncio.run(csr.sign_csr(new_key_label, issuer_name, CSR_PEM, keep_csr_extensions=False))
 
@@ -188,7 +188,7 @@ grASjklC2MWbAnXculQuvhPg5F54CK9WldMvd7oYAmbdGIWiffiL
         Sign a CSR with the key with the key_label in the pkcs11 device.
         """
 
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         exts = asn1_csr.Extensions()
 
         k_u = asn1_x509.KeyUsage(("100001100",))
@@ -249,7 +249,7 @@ grASjklC2MWbAnXculQuvhPg5F54CK9WldMvd7oYAmbdGIWiffiL
         Sign a CSR with the key with the key_label in the pkcs11 device.
         """
 
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         exts = asn1_csr.Extensions()
 
         k_u = asn1_x509.KeyUsage(("100001100",))

--- a/tests/test_ocsp.py
+++ b/tests/test_ocsp.py
@@ -212,7 +212,7 @@ class TestOCSP(unittest.TestCase):
         Create a signed_ocsp request.
         """
 
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         asyncio.run(PKCS11Session().create_keypair(new_key_label))
         i_name_h, i_key_h, serial, _ = certificate_ocsp_data(TEST_CERT)
         g_n = asn1_x509.GeneralName(name="directory_name", value=(asn1_ocsp.Name().build(requestor_name_dict)))
@@ -253,7 +253,7 @@ class TestOCSP(unittest.TestCase):
         Create an ocsp response.
         """
 
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         asyncio.run(PKCS11Session().create_keypair(new_key_label))
 
         i_name_h, i_key_h, serial, _ = certificate_ocsp_data(TEST_CERT)
@@ -295,7 +295,7 @@ class TestOCSP(unittest.TestCase):
         Create an ocsp responses with different cert status
         """
 
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         asyncio.run(PKCS11Session().create_keypair(new_key_label))
 
         i_name_h, i_key_h, serial, _ = certificate_ocsp_data(TEST_CERT)
@@ -356,7 +356,7 @@ class TestOCSP(unittest.TestCase):
         Create an unsuccessful ocsp response.
         """
 
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         asyncio.run(PKCS11Session().create_keypair(new_key_label))
 
         i_name_h, i_key_h, serial, _ = certificate_ocsp_data(TEST_CERT)
@@ -396,7 +396,7 @@ class TestOCSP(unittest.TestCase):
         Create an ocsp response with extra extensions.
         """
 
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         asyncio.run(PKCS11Session().create_keypair(new_key_label))
 
         i_name_h, i_key_h, serial, _ = certificate_ocsp_data(TEST_CERT)
@@ -662,7 +662,7 @@ FvdQ0EEx2Pssrry0iD5AieGyK2nKW94UA0gQenvtMS9mxQ==
 -----END CERTIFICATE-----
 """
 
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         asyncio.run(PKCS11Session().create_keypair(new_key_label))
 
         i_name_h, i_key_h, serial, _ = certificate_ocsp_data(TEST_CERT)

--- a/tests/test_pkcs11_handle.py
+++ b/tests/test_pkcs11_handle.py
@@ -12,7 +12,7 @@ from pkcs11 import Session
 from pkcs11.exceptions import MultipleObjectsReturned, NoSuchKey
 
 from src.python_x509_pkcs11.error import PKCS11UnknownErrorException
-from src.python_x509_pkcs11.lib import KEY_TYPE_VALUES, KEY_TYPES
+from src.python_x509_pkcs11.lib import KEY_TYPE_VALUES, KEYTYPES
 from src.python_x509_pkcs11.pkcs11_handle import PKCS11Session
 
 # Replace the above with this should you use this code
@@ -37,7 +37,7 @@ class TestPKCS11Handle(unittest.TestCase):
 
         assert isinstance(sess, Session)
         with self.assertRaises(NoSuchKey):
-            sess.get_key(label="test_not_exist", key_type=KEY_TYPE_VALUES["rsa_2048"])
+            sess.get_key(label="test_not_exist", key_type=KEY_TYPE_VALUES[KEYTYPES.RSA2048])
 
     def test_import_keypair_rsa(self) -> None:
         """Import keypair with key_label in the PKCS11 device.
@@ -139,9 +139,9 @@ class TestPKCS11Handle(unittest.TestCase):
         priv = b"0.\x02\x01\x000\x05\x06\x03+ep\x04\"\x04 ~n\xc3\xf5\x93\xb7\x1dYgO\x88\x90K\x9b\xe1&h\x0f\x0e@\xddh\xcc'\x98\xd2\xe7\xe7\xfb\x03T\xd1"  # pylint: disable=C0301
         pub = b"0*0\x05\x06\x03+ep\x03!\x00\x8b\x07J\x99[\xe4g\x9c\xd9\xfa'\x03\x9a\xb8\x01>&\x10\x1cay~\xadf\x80j\x9eq;\xb3\xf3\x9c"  # pylint: disable=C0301
 
-        for key_type in ["ed25519", None]:
+        for key_type in ["ed25519", KEYTYPES.ED25519]:
             imported_key_label = "imported_keypair_label_ed25519"
-            new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+            new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
 
             asyncio.run(PKCS11Session().create_keypair(new_key_label, key_type=key_type))
             pk_info, identifier = asyncio.run(PKCS11Session().public_key_data(new_key_label, key_type))
@@ -201,8 +201,8 @@ class TestPKCS11Handle(unittest.TestCase):
         priv = b"0G\x02\x01\x000\x05\x06\x03+eq\x04;\x049@\x02h\x89\xb4\xfdk\x05\xeblM\xe2\x8fT\x90QH\xacF\x8f\x9c\xd5\xf0b6U\x91Gu\x119Q\xff\x10\xae\x9fG\xe1\x7fiUu\xf3-\xdf\x9di(\xa26.\x93\x0f\xd6{#?"  # pylint: disable=C0301
         pub = b"0C0\x05\x06\x03+eq\x03:\x00N\x9e/u\xd35x]8k\xad\xbf\xf4\x06D\xf83\xcf\xea0\x91WS\xc0o\x17\x9f\xdc\xc7\xd8\xb2\x96\x07a\x14\xea\xf5\xcd\xe2D\xde\x8d\x15\xeb\x9b\xf6\xa7\xbe\r\x81\xa0\xfd\x10\xb2G \x80"  # pylint: disable=C0301
 
-        imported_key_label = "imported_keypair_label_ed448"
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        imported_key_label = "testpkcsimported_keypair_label_ed448"
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
 
         asyncio.run(PKCS11Session().create_keypair(new_key_label, key_type="ed448"))
         pk_info, identifier = asyncio.run(PKCS11Session().public_key_data(new_key_label, "ed448"))
@@ -262,8 +262,8 @@ class TestPKCS11Handle(unittest.TestCase):
         priv = b"0w\x02\x01\x01\x04 \xc1\x96a \xd3M\xe2\x04\xaaY\xe8{%F\x0eTt?\xa7\x0c\x85\xf3Hh\xbd,&\xe5\x8c\xb5\xa3[\xa0\n\x06\x08*\x86H\xce=\x03\x01\x07\xa1D\x03B\x00\x04\xae-\x90\t\xee-\x8d\xe4\x1b\xcfC\xb4TJ\x89[\x89\x82\x85+9\xb7\x96\xef\x12\xae\xfeG\x1f\xf7aX\x88\xca\xcf\xab9\x0b\xcd>\xb8\xfc\x95g\xa4\xca \r\x9d_\xa2\x1b1*\x17\x11\xc2\x8b\xd0\x98\x94Za\x82"  # pylint: disable=C0301
         pub = b"0Y0\x13\x06\x07*\x86H\xce=\x02\x01\x06\x08*\x86H\xce=\x03\x01\x07\x03B\x00\x04\xae-\x90\t\xee-\x8d\xe4\x1b\xcfC\xb4TJ\x89[\x89\x82\x85+9\xb7\x96\xef\x12\xae\xfeG\x1f\xf7aX\x88\xca\xcf\xab9\x0b\xcd>\xb8\xfc\x95g\xa4\xca \r\x9d_\xa2\x1b1*\x17\x11\xc2\x8b\xd0\x98\x94Za\x82"  # pylint: disable=C0301
 
-        imported_key_label = "imported_keypair_label_secp256r1"
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        imported_key_label = "testpkcsimported_keypair_label_secp256r1"
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
 
         asyncio.run(PKCS11Session().create_keypair(new_key_label, key_type="secp256r1"))
         pk_info, identifier = asyncio.run(PKCS11Session().public_key_data(new_key_label, "secp256r1"))
@@ -320,8 +320,8 @@ class TestPKCS11Handle(unittest.TestCase):
         priv = b'0\x81\xa4\x02\x01\x01\x040:-e\x12#\xab\xcb\xa3v\xfd\xc5\xe2W\x87\x82\x17\x1d\x7f\xbcg\x92\x7f\xc9\xe0G\xdde\x9e0\xf6\x00\x97\xcc\xda\x04\xa0\xda\xf9\x13\x86\x8e7x^\xa8\xbe\xd8\xd7\xa0\x07\x06\x05+\x81\x04\x00"\xa1d\x03b\x00\x04>\x11_\x9f\xb6z\xe6\xdc\xfc\xa7\x1a]\x02\x82\xbe\xdfh\xee\xca\xa6\xd6\xd9\x84\x87[m\x15\x11\xa7\xbea\x94<\x07!\xcb%7\xedFv\xaa\xe0\xf6\x9b\x9c\x00Bo\x1c\xc8\n\x8a\x86\xf6\x82\x15\xf5\x0e\xb98\xdf\x9f+\xb4\xfdG\x17\xc0O$a\xedz-\xc1[\xf1\xa5\xab\t\x1a\xdb>\x9d\xf5^\xb0 ,\xe4A\x9e\xfb\x17e'  # pylint: disable=C0301
         pub = b'0v0\x10\x06\x07*\x86H\xce=\x02\x01\x06\x05+\x81\x04\x00"\x03b\x00\x04>\x11_\x9f\xb6z\xe6\xdc\xfc\xa7\x1a]\x02\x82\xbe\xdfh\xee\xca\xa6\xd6\xd9\x84\x87[m\x15\x11\xa7\xbea\x94<\x07!\xcb%7\xedFv\xaa\xe0\xf6\x9b\x9c\x00Bo\x1c\xc8\n\x8a\x86\xf6\x82\x15\xf5\x0e\xb98\xdf\x9f+\xb4\xfdG\x17\xc0O$a\xedz-\xc1[\xf1\xa5\xab\t\x1a\xdb>\x9d\xf5^\xb0 ,\xe4A\x9e\xfb\x17e'  # pylint: disable=C0301
 
-        imported_key_label = "imported_keypair_label_secp384r1"
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        imported_key_label = "testpkcsimported_keypair_label_secp384r1"
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
 
         asyncio.run(PKCS11Session().create_keypair(new_key_label, key_type="secp384r1"))
         pk_info, identifier = asyncio.run(PKCS11Session().public_key_data(new_key_label, "secp384r1"))
@@ -382,8 +382,8 @@ class TestPKCS11Handle(unittest.TestCase):
         priv = b'0\x81\xdc\x02\x01\x01\x04B\x00T\xc7"\xc9&\xdb\xe8e\xb8\xf6\xb0\x8c\xd4\xd0\xc0\xbc\xf8\xd8?g\x17Bb:\xeeI\x86\xe6\x86\xb25W\x12\xa9F\x00\xbf\xee\xd7\xb7\xb5}\x9b]\x1a\xce\x97U\x05\x0cX\x19c\x1b\'?i\x94s0,\x175\xfe\x88\xa0\x07\x06\x05+\x81\x04\x00#\xa1\x81\x89\x03\x81\x86\x00\x04\x01\x04\x95"\xe0"\xc6g\xee\xa2:\\\xd9\xa0\x8f\xfa\xad\x07\xeco\t\xa7\x00~3}1\x949\x83\xef\x16-T\x1c\x90\x96) \x8e\x16\xa3\xc1\xd7\xcb\xa0I?\xdf\x07\x8e\xa0\xb8\x82F\xf0\x15\xaf4\x9d\xbb\xd7\xb85\xce\xd4\x01\xc6`\xbd?\xfc]\xa1\x18\x8c\xb9\xb8Z\x10\xb6\x9a&\xa9[\xc9{\xf9\x99\xcc\xe5\xb6\x80!R\xd6(\xa0\x08\xda%\xd45\x0ec[\x87^\xfa\xf7;\x10\t\x95\xbcf\xf1\x97\xd9B7\t\xb6w\x0ce\xec\x81\xe4\xd6~T'  # pylint: disable=C0301
         pub = b'0\x81\x9b0\x10\x06\x07*\x86H\xce=\x02\x01\x06\x05+\x81\x04\x00#\x03\x81\x86\x00\x04\x01\x04\x95"\xe0"\xc6g\xee\xa2:\\\xd9\xa0\x8f\xfa\xad\x07\xeco\t\xa7\x00~3}1\x949\x83\xef\x16-T\x1c\x90\x96) \x8e\x16\xa3\xc1\xd7\xcb\xa0I?\xdf\x07\x8e\xa0\xb8\x82F\xf0\x15\xaf4\x9d\xbb\xd7\xb85\xce\xd4\x01\xc6`\xbd?\xfc]\xa1\x18\x8c\xb9\xb8Z\x10\xb6\x9a&\xa9[\xc9{\xf9\x99\xcc\xe5\xb6\x80!R\xd6(\xa0\x08\xda%\xd45\x0ec[\x87^\xfa\xf7;\x10\t\x95\xbcf\xf1\x97\xd9B7\t\xb6w\x0ce\xec\x81\xe4\xd6~T'  # pylint: disable=C0301
 
-        imported_key_label = "imported_keypair_label_secp521r1"
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        imported_key_label = "testpkcsimported_keypair_label_secp521r1"
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
 
         asyncio.run(PKCS11Session().create_keypair(new_key_label, key_type="secp521r1"))
         pk_info, identifier = asyncio.run(PKCS11Session().public_key_data(new_key_label, "secp521r1"))
@@ -433,7 +433,7 @@ class TestPKCS11Handle(unittest.TestCase):
         with self.assertRaises(ValueError):
             asyncio.run(PKCS11Session().create_keypair("dummy", key_type="dummy_key_type"))
 
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         asyncio.run(PKCS11Session().create_keypair(new_key_label, key_type="rsa_2048"))
         pk_info, identifier = asyncio.run(PKCS11Session().public_key_data(new_key_label, key_type="rsa_2048"))
         self.assertTrue(isinstance(identifier, bytes))
@@ -486,8 +486,8 @@ class TestPKCS11Handle(unittest.TestCase):
         with self.assertRaises(ValueError):
             asyncio.run(PKCS11Session().delete_keypair("dummy", key_type="dummy_key_type"))
 
-        for key_type in KEY_TYPES:
-            new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        for key_type in KEYTYPES:
+            new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
 
             with self.assertRaises(NoSuchKey):
                 asyncio.run(PKCS11Session().delete_keypair(new_key_label, key_type=key_type))
@@ -506,8 +506,8 @@ class TestPKCS11Handle(unittest.TestCase):
         with self.assertRaises(ValueError):
             asyncio.run(PKCS11Session().public_key_data("dummy", key_type="dummy_key_type"))
 
-        for key_type in KEY_TYPES:
-            new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        for key_type in KEYTYPES:
+            new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
             asyncio.run(PKCS11Session().create_keypair(new_key_label, key_type=key_type))
             pk_info, identifier = asyncio.run(PKCS11Session().public_key_data(new_key_label, key_type=key_type))
             self.assertTrue(isinstance(identifier, bytes))
@@ -530,7 +530,7 @@ class TestPKCS11Handle(unittest.TestCase):
         with self.assertRaises(ValueError):
             asyncio.run(PKCS11Session().verify("dummy", b"dummy_data", b"dummy_sig", key_type="dummy_key_type"))
 
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         asyncio.run(PKCS11Session().create_keypair(new_key_label, key_type="rsa_2048"))
         data_to_be_signed = b"MY TEST DATA TO BE SIGNED HERE"
 
@@ -594,7 +594,7 @@ tnmQdMO1DA==
 -----END CERTIFICATE-----
 """
 
-        new_key_label = hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        new_key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         asyncio.run(PKCS11Session().import_certificate(cert_pem, new_key_label))
         with self.assertRaises(ValueError):
             asyncio.run(PKCS11Session().import_certificate(cert_pem, new_key_label))


### PR DESCRIPTION
Fixes #8 KEYTYPES is now a Python Enum

All public facing functions now take Union[str, KEYTYPES] where
KEYTYPES is a Python Enum and defaults to KEYTYPES.ED25519.

You can not send in `None` as key_type anymore. Sending a concrete
Enum type is the recomended way.

It also fixes #10, during test runs we creates keys with
"testpkcs" as prefix. Before and after the tests we delete all keys
with that prefix via `conftest.py`, but not on Github action.