### PR TITLE
Fixes #12 Adds privatekeys for various KEYTYPES

### DIFF
--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -38,15 +38,18 @@ jobs:
         run: |
           python3 -m venv .venv && . .venv/bin/activate && \
           python3 -m pip install --upgrade pip && \
-          pip3 install -r requirements.txt -r test_requirements.txt
+          python -m pip install -r requirements.txt -r test_requirements.txt
 
       - name: Setup softhsm2
         run: |
           make new_softhsm
 
+      # https://github.com/pyauth/python-pkcs11/issues/171
+      # . .venv/bin/activate && make test
       - name: Test
         run: |
-          . .venv/bin/activate && make test
+          . .venv/bin/activate && pytest -vv -s --ignore tests/test_privatekeys.py
+          . .venv/bin/activate && pytest -vv -s tests/test_privatekeys.py
 
       - name: Mark github workspace as safe
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,9 @@
 
 - Fixed #3 singleton class for PKCS11Session.
 - Fixed #6 constants are now UPPER CASE.
+- Fixed #8 We now have KEYTYPES as Enum for every public function.
+
+### Fixed
+
+- Fixed #10 all test keys are prefixed with "testpkcs".
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Code comments added with RFC 5280 links for explanation.
+- Fixed #12 Add different Private Key types for cryptography module.
 
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ home-page = "https://github.com/SUNET/python_x509_pkcs11"
 requires = [
     "asn1crypto>=1.5.1",
     "python-pkcs11>=0.7.0",
-    "aiohttp"
+    "aiohttp",
+    "cryptography"
 ]
 
 [tool.mypy]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 asn1crypto >= 1.5.1
 python-pkcs11 >= 0.7.0
 aiohttp
+cryptography

--- a/src/python_x509_pkcs11/privatekeys.py
+++ b/src/python_x509_pkcs11/privatekeys.py
@@ -1,0 +1,237 @@
+"Private key implementations for cryptography.x509 usage"
+
+import asyncio
+from typing import Union
+
+from cryptography.hazmat.primitives import _serialization, hashes
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives.asymmetric import utils as asym_utils
+from cryptography.hazmat.primitives.asymmetric.ec import (
+    ECDH,
+    EllipticCurve,
+    EllipticCurvePrivateNumbers,
+    EllipticCurvePublicKey,
+    EllipticCurveSignatureAlgorithm,
+)
+from cryptography.hazmat.primitives.asymmetric.ed448 import Ed448PrivateKey, Ed448PublicKey
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+from cryptography.hazmat.primitives._asymmetric import (
+    AsymmetricPadding as AsymmetricPadding,
+)
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
+
+from .lib import KEYTYPES
+from .pkcs11_handle import PKCS11Session
+
+
+class PKCS11RSAPrivateKey(rsa.RSAPrivateKey):
+    "RSA private key implementation for HSM."
+
+    def __init__(self, key_label: str, key_type: KEYTYPES):
+        self.key_label = key_label
+        self.key_type = key_type
+
+    def sign(
+        self,
+        data: bytes,
+        padding: AsymmetricPadding,
+        algorithm: Union[asym_utils.Prehashed, hashes.HashAlgorithm],
+    ) -> bytes:
+        """Signs the given data using RSA key in PKCS11 device.
+
+        :param data: bytes, data to be signed.
+        :param padding: (NOT IN USE) padding to be used.
+        :param algorithm: (NOT IN USE) hash algorithm to be used.
+
+        :returns: signature in bytes
+        """
+        pkcs = PKCS11Session()
+        return asyncio.run(pkcs.sign(key_label=self.key_label, data=data, key_type=self.key_type))
+
+    # Following methods are not implemented.
+    def decrypt(self, ciphertext: bytes, padding: AsymmetricPadding) -> bytes:
+        raise NotImplementedError()
+
+    @property
+    def key_size(self) -> int:
+        raise NotImplementedError()
+
+    def public_key(self) -> "rsa.RSAPublicKey":
+        "Returns the public key."
+        public_key, _ = asyncio.run(PKCS11Session().public_key_data(self.key_label, self.key_type))
+        # This is the issuer public key
+        key = load_pem_public_key(public_key.encode("utf-8"))
+        if isinstance(key, rsa.RSAPublicKey):
+            return key
+        raise ValueError("Wrong Public key value.")
+
+    def private_numbers(self) -> "rsa.RSAPrivateNumbers":
+        raise NotImplementedError()
+
+    def private_bytes(
+        self,
+        encoding: _serialization.Encoding,
+        format: _serialization.PrivateFormat,
+        encryption_algorithm: _serialization.KeySerializationEncryption,
+    ) -> bytes:
+        raise NotImplementedError()
+
+
+class PKCS11ECPrivateKey(ec.EllipticCurvePrivateKey):
+    "EC private key implementation for HSM."
+
+    def __init__(self, key_label: str, key_type: KEYTYPES):
+        self.key_label = key_label
+        self.key_type = key_type
+
+    def sign(
+        self,
+        data: bytes,
+        signature_algorithm: EllipticCurveSignatureAlgorithm,
+    ) -> bytes:
+        """Signs the given data using EC key in PKCS11 device.
+
+        :param data: bytes, data to be signed.
+        :param signature_algorithm: (NOT IN USE) hash algorithm to be used.
+
+        :returns: signature in bytes
+        """
+        pkcs = PKCS11Session()
+        return asyncio.run(pkcs.sign(key_label=self.key_label, data=data, key_type=self.key_type))
+
+    def exchange(self, algorithm: ECDH, peer_public_key: EllipticCurvePublicKey) -> bytes:
+        raise NotImplementedError()
+
+    def public_key(self) -> EllipticCurvePublicKey:
+        "The EllipticCurvePublicKey for this private key."
+        public_key, _ = asyncio.run(PKCS11Session().public_key_data(self.key_label, self.key_type))
+        # This is the issuer public key
+        key = load_pem_public_key(public_key.encode("utf-8"))
+        if isinstance(key, ec.EllipticCurvePublicKey):
+            return key
+        raise ValueError("Wrong Public key value.")
+
+    @property
+    def curve(self) -> EllipticCurve:
+        """
+        The EllipticCurve that this key is on.
+        """
+        raise NotImplementedError()
+
+    @property
+    def key_size(self) -> int:
+        """
+        Bit size of a secret scalar for the curve.
+        """
+        raise NotImplementedError()
+
+    def private_numbers(self) -> EllipticCurvePrivateNumbers:
+        """
+        Returns an EllipticCurvePrivateNumbers.
+        """
+        raise NotImplementedError()
+
+    def private_bytes(
+        self,
+        encoding: _serialization.Encoding,
+        format: _serialization.PrivateFormat,
+        encryption_algorithm: _serialization.KeySerializationEncryption,
+    ) -> bytes:
+        """
+        Returns the key serialized as bytes.
+        """
+        raise NotImplementedError()
+
+
+class PKCS11ED25519PrivateKey(Ed25519PrivateKey):
+    "ED25519 private key implementation for HSM."
+
+    def __init__(self, key_label: str, key_type: KEYTYPES):
+        self.key_label = key_label
+        self.key_type = key_type
+
+    def public_key(self) -> Ed25519PublicKey:
+        """
+        The Ed25519PublicKey derived from the private key.
+        """
+        public_key, _ = asyncio.run(PKCS11Session().public_key_data(self.key_label, self.key_type))
+        # This is the issuer public key
+        key = load_pem_public_key(public_key.encode("utf-8"))
+        if isinstance(key, Ed25519PublicKey):
+            return key
+        raise ValueError("Wrong Public key value.")
+
+    def private_bytes(
+        self,
+        encoding: _serialization.Encoding,
+        format: _serialization.PrivateFormat,
+        encryption_algorithm: _serialization.KeySerializationEncryption,
+    ) -> bytes:
+        """
+        The serialized bytes of the private key.
+        """
+        raise NotImplementedError()
+
+    def private_bytes_raw(self) -> bytes:
+        """
+        The raw bytes of the private key.
+        Equivalent to private_bytes(Raw, Raw, NoEncryption()).
+        """
+        raise NotImplementedError()
+
+    def sign(self, data: bytes) -> bytes:
+        """Signs the given data using ED25519 key in PKCS11 device.
+
+        :param data: bytes, data to be signed.
+
+        :returns: signature in bytes
+        """
+        pkcs = PKCS11Session()
+        return asyncio.run(pkcs.sign(key_label=self.key_label, data=data, key_type=self.key_type))
+
+
+class PKCS11ED448PrivateKey(Ed448PrivateKey):
+    "ED448 private key implementation for HSM."
+
+    def __init__(self, key_label: str, key_type: KEYTYPES):
+        self.key_label = key_label
+        self.key_type = key_type
+
+    def sign(self, data: bytes) -> bytes:
+        """Signs the given data using ED25519 key in PKCS11 device.
+
+        :param data: bytes, data to be signed.
+
+        :returns: signature in bytes
+        """
+        pkcs = PKCS11Session()
+        return asyncio.run(pkcs.sign(key_label=self.key_label, data=data, key_type=self.key_type))
+
+    def public_key(self) -> Ed448PublicKey:
+        """
+        The Ed448PublicKey derived from the private key.
+        """
+        public_key, _ = asyncio.run(PKCS11Session().public_key_data(self.key_label, self.key_type))
+        # This is the issuer public key
+        key = load_pem_public_key(public_key.encode("utf-8"))
+        if isinstance(key, Ed448PublicKey):
+            return key
+        raise ValueError("Wrong Public key value.")
+
+    def private_bytes(
+        self,
+        encoding: _serialization.Encoding,
+        format: _serialization.PrivateFormat,
+        encryption_algorithm: _serialization.KeySerializationEncryption,
+    ) -> bytes:
+        """
+        The serialized bytes of the private key.
+        """
+        raise NotImplementedError()
+
+    def private_bytes_raw(self) -> bytes:
+        """
+        The raw bytes of the private key.
+        Equivalent to private_bytes(Raw, Raw, NoEncryption()).
+        """
+        raise NotImplementedError()

--- a/tests/test_pkcs11_handle.py
+++ b/tests/test_pkcs11_handle.py
@@ -18,11 +18,26 @@ from src.python_x509_pkcs11.pkcs11_handle import PKCS11Session
 # Replace the above with this should you use this code
 # from python_x509_pkcs11.pkcs11_handle import PKCS11Session
 
+async def delete_keys():
+    "We delete keys in a loop"
+
+    # No need to delete keys in github actions.
+    session = PKCS11Session()
+    keys = await session.key_labels()
+    for key_label, key_type in keys.items():
+        if key_label == "test_pkcs11_device_do_not_use":
+            continue
+        if key_label.startswith("testpkcs"):
+            await session.delete_keypair(key_label, key_type)
 
 class TestPKCS11Handle(unittest.TestCase):
     """
     Test our PKCS11 session handler.
     """
+
+    def tearDown(self):
+        "Cleans up test keys."
+        asyncio.run(delete_keys())
 
     def test_session(self) -> None:
         """Test PKCS11 session"""

--- a/tests/test_privatekeys.py
+++ b/tests/test_privatekeys.py
@@ -1,0 +1,144 @@
+import asyncio
+import datetime
+import os
+import unittest
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
+from cryptography.x509 import ObjectIdentifier
+from cryptography.x509.oid import NameOID
+
+from src.python_x509_pkcs11.lib import KEYTYPES
+from src.python_x509_pkcs11.pkcs11_handle import PKCS11Session
+from src.python_x509_pkcs11.privatekeys import (
+    PKCS11ECPrivateKey,
+    PKCS11ED448PrivateKey,
+    PKCS11ED25519PrivateKey,
+    PKCS11RSAPrivateKey,
+)
+
+not_valid_before = datetime.datetime.now()
+not_valid_after = not_valid_before + datetime.timedelta(days=90)
+subject_private_key = rsa.generate_private_key(65537, 2048)
+name = x509.Name(
+    [
+        x509.NameAttribute(NameOID.COUNTRY_NAME, "SE"),
+        x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "Stockholm"),
+        x509.NameAttribute(NameOID.LOCALITY_NAME, "Stockholm"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Sunet"),
+        x509.NameAttribute(NameOID.COMMON_NAME, "sunet.se"),
+    ]
+)
+
+
+def get_builder() -> x509.CertificateBuilder:
+    "Helper function for test"
+    builder = (
+        x509.CertificateBuilder()
+        .serial_number(x509.random_serial_number())
+        .issuer_name(name)
+        .subject_name(name)
+        .public_key(subject_private_key.public_key())
+        .add_extension(
+            x509.BasicConstraints(ca=False, path_length=None),
+            True,
+        )
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName("sunet.se")]),
+            critical=False,
+        )
+        .not_valid_before(not_valid_before)
+        .not_valid_after(not_valid_after)
+    )
+    return builder
+
+
+class TestPrivateKeys(unittest.TestCase):
+
+    def test_rsa_private_key(self) -> None:
+        "Tests HSM based RSA private key usage."
+        key_label = "testpkcs" + hex(int.from_bytes(os.urandom(8), "big") >> 1)
+        # First let us create an RSA4096 private key.
+        asyncio.run(PKCS11Session().create_keypair(key_label, key_type=KEYTYPES.RSA4096))
+
+        issuer_private_key = PKCS11RSAPrivateKey(key_label, KEYTYPES.RSA4096)
+        # This is the issuer public key
+        issuer_public_key = issuer_private_key.public_key()
+
+        builder = get_builder()
+        cert = builder.sign(issuer_private_key, hashes.SHA512())
+
+        # "1.2.840.113549.1.1.13"
+        # https://cryptography.io/en/latest/x509/reference/#cryptography.x509.oid.SignatureAlgorithmOID.RSA_WITH_SHA512
+        oid = ObjectIdentifier("1.2.840.113549.1.1.13")
+        self.assertEqual(cert.signature_algorithm_oid, oid)
+
+        # Now verify the signature of the certificate
+        issuer_public_key.verify(
+            cert.signature, cert.tbs_certificate_bytes, padding.PKCS1v15(), cert.signature_hash_algorithm
+        )
+
+    def test_ec_private_key(self) -> None:
+        "Tests HSM based ec private key usage."
+        key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        # First let us create an SECP521r1 private key.
+        asyncio.run(PKCS11Session().create_keypair(key_label, key_type=KEYTYPES.SECP521r1))
+
+        issuer_private_key = PKCS11ECPrivateKey(key_label, KEYTYPES.SECP521r1)
+        # This is the issuer public key
+        issuer_public_key = issuer_private_key.public_key()
+
+        builder = get_builder()
+        cert = builder.sign(issuer_private_key, hashes.SHA512())
+
+        # "1.2.840.10045.4.3.4" is for ECDSA wtih SHA512 hash
+        # https://cryptography.io/en/latest/x509/reference/#cryptography.x509.oid.SignatureAlgorithmOID.ECDSA_WITH_SHA512
+        oid = ObjectIdentifier("1.2.840.10045.4.3.4")
+        self.assertEqual(cert.signature_algorithm_oid, oid)
+
+        # Now verify the signature of the certificate
+        issuer_public_key.verify(cert.signature, cert.tbs_certificate_bytes, ec.ECDSA(cert.signature_hash_algorithm))
+
+    def test_ed25519_private_key(self) -> None:
+        "Tests HSM based ed25519 private key usage."
+        key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        # First let us create an ED25519 private key.
+        asyncio.run(PKCS11Session().create_keypair(key_label, key_type=KEYTYPES.ED25519))
+
+        issuer_private_key = PKCS11ED25519PrivateKey(key_label, KEYTYPES.ED25519)
+        # This is the issuer public key
+        issuer_public_key = issuer_private_key.public_key()
+
+        builder = get_builder()
+        cert = builder.sign(issuer_private_key, None)
+
+        # "1.3.101.112" is for ED25519 keys
+        # https://cryptography.io/en/latest/x509/reference/#cryptography.x509.oid.SignatureAlgorithmOID.ED25519
+        oid = ObjectIdentifier("1.3.101.112")
+        self.assertEqual(cert.signature_algorithm_oid, oid)
+
+        # Now verify the signature of the certificate
+        issuer_public_key.verify(cert.signature, cert.tbs_certificate_bytes)
+
+    def test_ed448_private_key(self) -> None:
+        "Tests HSM based ed448 private key usage."
+        key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
+        # First let us create an ED25519 private key.
+        asyncio.run(PKCS11Session().create_keypair(key_label, key_type=KEYTYPES.ED448))
+
+        issuer_private_key = PKCS11ED448PrivateKey(key_label, KEYTYPES.ED448)
+        # This is the issuer public key
+        issuer_public_key = issuer_private_key.public_key()
+
+        builder = get_builder()
+        cert = builder.sign(issuer_private_key, None)
+
+        # "1.3.101.113" is for ED448 keys
+        # https://cryptography.io/en/latest/x509/reference/#cryptography.x509.oid.SignatureAlgorithmOID.ED448
+        oid = ObjectIdentifier("1.3.101.113")
+        self.assertEqual(cert.signature_algorithm_oid, oid)
+
+        # Now verify the signature of the certificate
+        issuer_public_key.verify(cert.signature, cert.tbs_certificate_bytes)


### PR DESCRIPTION
- PKCS11RSAPrivateKey
- PKCS11ECPrivateKey
- PKCS11ED25519PrivateKey
- PKCS11ED448PrivateKey
 
Provides `sign` and `public_key` methods for each of them.
Also adds cryptography as a runtime dependency.
Cleans up test keys after run for the pkcs11 session test.

