### PR TITLE
Pass session to private keys to make session objects reusable

### DIFF
--- a/src/python_x509_pkcs11/privatekeys.py
+++ b/src/python_x509_pkcs11/privatekeys.py
@@ -25,7 +25,8 @@ from .pkcs11_handle import PKCS11Session
 class PKCS11RSAPrivateKey(rsa.RSAPrivateKey):
     "RSA private key implementation for HSM."
 
-    def __init__(self, key_label: str, key_type: KEYTYPES):
+    def __init__(self, session: PKCS11Session, key_label: str, key_type: KEYTYPES):
+        self.session = session
         self.key_label = key_label
         self.key_type = key_type
 
@@ -43,8 +44,7 @@ class PKCS11RSAPrivateKey(rsa.RSAPrivateKey):
 
         :returns: signature in bytes
         """
-        pkcs = PKCS11Session()
-        return asyncio.run(pkcs.sign(key_label=self.key_label, data=data, key_type=self.key_type))
+        return asyncio.run(self.session.sign(key_label=self.key_label, data=data, key_type=self.key_type))
 
     # Following methods are not implemented.
     def decrypt(self, ciphertext: bytes, padding: AsymmetricPadding) -> bytes:
@@ -78,7 +78,8 @@ class PKCS11RSAPrivateKey(rsa.RSAPrivateKey):
 class PKCS11ECPrivateKey(ec.EllipticCurvePrivateKey):
     "EC private key implementation for HSM."
 
-    def __init__(self, key_label: str, key_type: KEYTYPES):
+    def __init__(self, session: PKCS11Session, key_label: str, key_type: KEYTYPES):
+        self.session = session
         self.key_label = key_label
         self.key_type = key_type
 
@@ -94,8 +95,7 @@ class PKCS11ECPrivateKey(ec.EllipticCurvePrivateKey):
 
         :returns: signature in bytes
         """
-        pkcs = PKCS11Session()
-        return asyncio.run(pkcs.sign(key_label=self.key_label, data=data, key_type=self.key_type))
+        return asyncio.run(self.session.sign(key_label=self.key_label, data=data, key_type=self.key_type))
 
     def exchange(self, algorithm: ECDH, peer_public_key: EllipticCurvePublicKey) -> bytes:
         raise NotImplementedError()
@@ -144,7 +144,8 @@ class PKCS11ECPrivateKey(ec.EllipticCurvePrivateKey):
 class PKCS11ED25519PrivateKey(Ed25519PrivateKey):
     "ED25519 private key implementation for HSM."
 
-    def __init__(self, key_label: str, key_type: KEYTYPES = KEYTYPES.ED25519):
+    def __init__(self, session: PKCS11Session, key_label: str, key_type: KEYTYPES = KEYTYPES.ED25519):
+        self.session = session
         self.key_label = key_label
         self.key_type = key_type
 
@@ -184,14 +185,14 @@ class PKCS11ED25519PrivateKey(Ed25519PrivateKey):
 
         :returns: signature in bytes
         """
-        pkcs = PKCS11Session()
-        return asyncio.run(pkcs.sign(key_label=self.key_label, data=data, key_type=self.key_type))
+        return asyncio.run(self.session.sign(key_label=self.key_label, data=data, key_type=self.key_type))
 
 
 class PKCS11ED448PrivateKey(Ed448PrivateKey):
     "ED448 private key implementation for HSM."
 
-    def __init__(self, key_label: str, key_type: KEYTYPES = KEYTYPES.ED448):
+    def __init__(self, session: PKCS11Session, key_label: str, key_type: KEYTYPES = KEYTYPES.ED448):
+        self.session = session
         self.key_label = key_label
         self.key_type = key_type
 
@@ -202,8 +203,7 @@ class PKCS11ED448PrivateKey(Ed448PrivateKey):
 
         :returns: signature in bytes
         """
-        pkcs = PKCS11Session()
-        return asyncio.run(pkcs.sign(key_label=self.key_label, data=data, key_type=self.key_type))
+        return asyncio.run(self.session.sign(key_label=self.key_label, data=data, key_type=self.key_type))
 
     def public_key(self) -> Ed448PublicKey:
         """

--- a/tests/test_privatekeys.py
+++ b/tests/test_privatekeys.py
@@ -69,12 +69,13 @@ class TestPrivateKeys:
 
     def test_rsa2048_private_key(self) -> None:
         "Tests HSM based RSA private key usage."
+        session = PKCS11Session()
         key_label = "testpkcs" + hex(int.from_bytes(os.urandom(8), "big") >> 1)
         # First let us create an RSA2048 private key.
         asyncio.run(delete_keys())
-        asyncio.run(PKCS11Session().create_keypair(key_label, key_type=KEYTYPES.RSA2048))
+        asyncio.run(session.create_keypair(key_label, key_type=KEYTYPES.RSA2048))
 
-        issuer_private_key = PKCS11RSAPrivateKey(key_label, KEYTYPES.RSA2048)
+        issuer_private_key = PKCS11RSAPrivateKey(session, key_label, KEYTYPES.RSA2048)
         # This is the issuer public key
         issuer_public_key = issuer_private_key.public_key()
 
@@ -93,12 +94,13 @@ class TestPrivateKeys:
 
     def test_rsa4096_private_key(self) -> None:
         "Tests HSM based RSA private key usage."
+        session = PKCS11Session()
         key_label = "testpkcs" + hex(int.from_bytes(os.urandom(8), "big") >> 1)
         # First let us create an RSA4096 private key.
         asyncio.run(delete_keys())
-        asyncio.run(PKCS11Session().create_keypair(key_label, key_type=KEYTYPES.RSA4096))
+        asyncio.run(session.create_keypair(key_label, key_type=KEYTYPES.RSA4096))
 
-        issuer_private_key = PKCS11RSAPrivateKey(key_label, KEYTYPES.RSA4096)
+        issuer_private_key = PKCS11RSAPrivateKey(session, key_label, KEYTYPES.RSA4096)
         # This is the issuer public key
         issuer_public_key = issuer_private_key.public_key()
 
@@ -117,11 +119,12 @@ class TestPrivateKeys:
 
     def test_ec_private_key(self) -> None:
         "Tests HSM based ec private key usage."
+        session = PKCS11Session()
         key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         # First let us create an SECP521r1 private key.
-        asyncio.run(PKCS11Session().create_keypair(key_label, key_type=KEYTYPES.SECP521r1))
+        asyncio.run(session.create_keypair(key_label, key_type=KEYTYPES.SECP521r1))
 
-        issuer_private_key = PKCS11ECPrivateKey(key_label, KEYTYPES.SECP521r1)
+        issuer_private_key = PKCS11ECPrivateKey(session, key_label, KEYTYPES.SECP521r1)
         # This is the issuer public key
         issuer_public_key = issuer_private_key.public_key()
 
@@ -138,11 +141,12 @@ class TestPrivateKeys:
 
     def test_ed25519_private_key(self) -> None:
         "Tests HSM based ed25519 private key usage."
+        session = PKCS11Session()
         key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         # First let us create an ED25519 private key.
-        asyncio.run(PKCS11Session().create_keypair(key_label, key_type=KEYTYPES.ED25519))
+        asyncio.run(session.create_keypair(key_label, key_type=KEYTYPES.ED25519))
 
-        issuer_private_key = PKCS11ED25519PrivateKey(key_label, KEYTYPES.ED25519)
+        issuer_private_key = PKCS11ED25519PrivateKey(session, key_label, KEYTYPES.ED25519)
         # This is the issuer public key
         issuer_public_key = issuer_private_key.public_key()
 
@@ -159,11 +163,12 @@ class TestPrivateKeys:
 
     def test_ed448_private_key(self) -> None:
         "Tests HSM based ed448 private key usage."
+        session = PKCS11Session()
         key_label = "testpkcs" + hex(int.from_bytes(os.urandom(20), "big") >> 1)
         # First let us create an ED25519 private key.
-        asyncio.run(PKCS11Session().create_keypair(key_label, key_type=KEYTYPES.ED448))
+        asyncio.run(session.create_keypair(key_label, key_type=KEYTYPES.ED448))
 
-        issuer_private_key = PKCS11ED448PrivateKey(key_label, KEYTYPES.ED448)
+        issuer_private_key = PKCS11ED448PrivateKey(session, key_label, KEYTYPES.ED448)
         # This is the issuer public key
         issuer_public_key = issuer_private_key.public_key()
 


### PR DESCRIPTION
Pass the PKCS11Session object directly to the key constructor of private key objects.

The default session object gets its configuration from environment variables, which is not a good approach in many environments. I need to use sessions with custom configurations instead.